### PR TITLE
Item Group is now auto added on item registration

### DIFF
--- a/src/main/java/net/distantdig/immersive_currency/block/BlockRegister.java
+++ b/src/main/java/net/distantdig/immersive_currency/block/BlockRegister.java
@@ -1,6 +1,7 @@
 package net.distantdig.immersive_currency.block;
 
 import net.distantdig.immersive_currency.ImmersiveCurrency;
+import net.distantdig.immersive_currency.item.ModItemGroups;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
 import net.fabricmc.fabric.api.screenhandler.v1.ScreenHandlerRegistry;
@@ -55,7 +56,9 @@ public final class BlockRegister {
                 new BlockItem(data.block, new FabricItemSettings())
         );
         blockMap.put(key, data);
-    };
+
+        ModItemGroups.addToBlockGroupList(data.item);
+    }
     public static <T extends BlockEntity> void registerBlockEntity(String key, FabricBlockEntityTypeBuilder.Factory<T> ctor, Block... blocks){
         blockEntityMap.put(key, Registry.register(
                 BuiltInRegistries.BLOCK_ENTITY_TYPE,

--- a/src/main/java/net/distantdig/immersive_currency/block/ModBlocks.java
+++ b/src/main/java/net/distantdig/immersive_currency/block/ModBlocks.java
@@ -1,42 +1,31 @@
 package net.distantdig.immersive_currency.block;
 
-import com.mojang.datafixers.util.Pair;
 import net.distantdig.immersive_currency.ImmersiveCurrency;
 import net.distantdig.immersive_currency.block.custom.BarBlock;
 import net.distantdig.immersive_currency.block.custom.CoinBlock;
+import net.distantdig.immersive_currency.item.ModItemGroups;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.object.builder.v1.block.FabricBlockSettings;
 import net.minecraft.core.Registry;
-import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.registries.BuiltInRegistries;
-import net.minecraft.resources.RegistryOps;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.BlockItem;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.SlabBlock;
-import net.minecraft.world.level.block.StairBlock;
-import net.minecraft.world.level.block.state.BlockBehaviour;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.Supplier;
 
 public class ModBlocks {
-    public static final BarBlock PURE_COPPER_INGOT = registerBarBlock("pure_copper_ingot", new BarBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
-    public static final BarBlock PURE_IRON_INGOT = registerBarBlock("pure_iron_ingot", new BarBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
-    public static final BarBlock PURE_GOLD_INGOT = registerBarBlock("pure_gold_ingot", new BarBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
-    public static final BarBlock PURE_PLATINUM_INGOT = registerBarBlock("pure_platinum_ingot", new BarBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
+
     public static final CoinBlock COPPER_COIN = registerCoinBlock("copper_coin", new CoinBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
     public static final CoinBlock IRON_COIN = registerCoinBlock("iron_coin", new CoinBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
     public static final CoinBlock GOLD_COIN = registerCoinBlock("gold_coin", new CoinBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
     public static final CoinBlock PLATINUM_COIN = registerCoinBlock("platinum_coin", new CoinBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
 
-    private static Block registerBlock(String name, Block block) {
-        registerBlockItem(name, block);
-        return Registry.register(BuiltInRegistries.BLOCK, new ResourceLocation(ImmersiveCurrency.MOD_ID, name), block);
-    }
+    public static final BarBlock PURE_COPPER_INGOT = registerBarBlock("pure_copper_ingot", new BarBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
+    public static final BarBlock PURE_IRON_INGOT = registerBarBlock("pure_iron_ingot", new BarBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
+    public static final BarBlock PURE_GOLD_INGOT = registerBarBlock("pure_gold_ingot", new BarBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
+    public static final BarBlock PURE_PLATINUM_INGOT = registerBarBlock("pure_platinum_ingot", new BarBlock(FabricBlockSettings.copyOf(Blocks.GOLD_BLOCK).nonOpaque()));
+
     private static Item registerBlockItem(String name, Block block) {
         return Registry.register(BuiltInRegistries.ITEM, new ResourceLocation(ImmersiveCurrency.MOD_ID, name),
                 new BlockItem(block, new FabricItemSettings()));
@@ -44,12 +33,16 @@ public class ModBlocks {
 
     private static BarBlock registerBarBlock(String name, BarBlock barBlock) {
         registerBlockItem(name, barBlock);
-        return Registry.register(BuiltInRegistries.BLOCK, new ResourceLocation(ImmersiveCurrency.MOD_ID, name), barBlock);
+        BarBlock BlockRegistered = Registry.register(BuiltInRegistries.BLOCK, new ResourceLocation(ImmersiveCurrency.MOD_ID, name), barBlock);
+        ModItemGroups.addToPriorityGroupList(BlockRegistered);
+        return BlockRegistered;
     }
 
     private static CoinBlock registerCoinBlock(String name, CoinBlock coinBlock) {
         registerBlockItem(name, coinBlock);
-        return Registry.register(BuiltInRegistries.BLOCK, new ResourceLocation(ImmersiveCurrency.MOD_ID, name), coinBlock);
+        CoinBlock BlockRegistered = Registry.register(BuiltInRegistries.BLOCK, new ResourceLocation(ImmersiveCurrency.MOD_ID, name), coinBlock);
+        ModItemGroups.addToPriorityGroupList(BlockRegistered);
+        return BlockRegistered;
     }
 
     //do same for walls, stairs, slabs.

--- a/src/main/java/net/distantdig/immersive_currency/item/ModItemGroups.java
+++ b/src/main/java/net/distantdig/immersive_currency/item/ModItemGroups.java
@@ -1,7 +1,6 @@
 package net.distantdig.immersive_currency.item;
 
 import net.distantdig.immersive_currency.ImmersiveCurrency;
-import net.distantdig.immersive_currency.block.BlockRegister;
 import net.distantdig.immersive_currency.block.ModBlocks;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
 import net.minecraft.core.Registry;
@@ -10,29 +9,32 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTab;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ItemLike;
+
+import java.util.ArrayList;
 import java.util.function.BiConsumer;
 
 public class ModItemGroups {
 
-    private static final BiConsumer<CreativeModeTab.ItemDisplayParameters, CreativeModeTab.Output> consumer = (displayContext, entries) -> {
-        //these few are added the old fasioned way because these are blocks which are special, aka, they have an item texture lmao
-        entries.accept(ModBlocks.COPPER_COIN);
-        entries.accept(ModBlocks.IRON_COIN);
-        entries.accept(ModBlocks.GOLD_COIN);
-        entries.accept(ModBlocks.PLATINUM_COIN);
-        entries.accept(ModBlocks.PURE_COPPER_INGOT);
-        entries.accept(ModBlocks.PURE_IRON_INGOT);
-        entries.accept(ModBlocks.PURE_GOLD_INGOT);
-        entries.accept(ModBlocks.PURE_PLATINUM_INGOT);
-        //this generates the list for all generic items
-        ModItems.itemList.forEach((key, value) -> {
-            entries.accept(value);
-        });
-        //this generates the list for all generic blocks
-        BlockRegister.blockMap.forEach((key, value) -> {
-            entries.accept(value.item);
-        });
+    public static ArrayList<ItemLike> PriorityGroupList = new ArrayList<>();
+    public static ArrayList<ItemLike> ItemGroupList = new ArrayList<>();
+    public static ArrayList<ItemLike> BlockGroupList = new ArrayList<>();
+
+    private static BiConsumer<CreativeModeTab.ItemDisplayParameters, CreativeModeTab.Output> consumer = (displayContext, entries) -> {
+        PriorityGroupList.forEach(entries::accept);
+        ItemGroupList.forEach(entries::accept);
+        BlockGroupList.forEach(entries::accept);
     };
+
+    public static void addToPriorityGroupList(ItemLike itemLike){
+        PriorityGroupList.add(itemLike);
+    }
+    public static void addToItemGroupList(ItemLike itemLike){
+        ItemGroupList.add(itemLike);
+    }
+    public static void addToBlockGroupList(ItemLike itemLike){
+        BlockGroupList.add(itemLike);
+    }
 
     public static final CreativeModeTab IMMERSIVE_COINS_GROUP = Registry.register(BuiltInRegistries.CREATIVE_MODE_TAB,
             new ResourceLocation(ImmersiveCurrency.MOD_ID, "immersive_coins_group"),

--- a/src/main/java/net/distantdig/immersive_currency/item/ModItems.java
+++ b/src/main/java/net/distantdig/immersive_currency/item/ModItems.java
@@ -12,7 +12,6 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.CreativeModeTabs;
 import net.minecraft.world.item.Item;
 
-import java.util.List;
 import java.util.Map;
 
 public class ModItems {
@@ -40,21 +39,13 @@ public class ModItems {
     public static final Item EMERALD_SHARD = itemList.get("emerald_shard");
 
     private static void acceptItemsToItemGroup(FabricItemGroupEntries entries) {
-        entries.accept(COIN_POUCH);
-
-        entries.accept(PURE_COPPER_NUGGET);
-        entries.accept(PURE_IRON_NUGGET);
-        entries.accept(PURE_GOLD_NUGGET);
-        entries.accept(PURE_PLATINUM_NUGGET);
-
-        entries.accept(LARGE_EMERALD);
-        entries.accept(EMERALD_CHUNK);
-        entries.accept(EMERALD_SHARD);
+        ModItemGroups.ItemGroupList.forEach(entries::accept);
     }
 
-
     private static Item registerItem(String name, Item item) {
-        return Registry.register(BuiltInRegistries.ITEM, new ResourceLocation(ImmersiveCurrency.MOD_ID, name), item);
+        Item itemRegistered = Registry.register(BuiltInRegistries.ITEM, new ResourceLocation(ImmersiveCurrency.MOD_ID, name), item);
+        ModItemGroups.addToItemGroupList(itemRegistered);
+        return itemRegistered;
     }
     public static void registerModItems() {
         ImmersiveCurrency.LOGGER.info("Registering Mod Items for " + ImmersiveCurrency.MOD_ID);


### PR DESCRIPTION
There are now three lists to add items to on item registration. In block registration, block items are auto added to the block list. Items are added to the item list in ModItems, and the third list is the Priority list which is listed first in the group. I added the coins and ingots to the priority list, and then all items and blocks are in their respective lists. The lists are added to the item group in the following order: Priority List, Item List, Block List.